### PR TITLE
Fix error: Unhandled media type Mjs

### DIFF
--- a/src/deno.ts
+++ b/src/deno.ts
@@ -1,5 +1,6 @@
 export type MediaType =
   | "JavaScript"
+  | "Mjs"
   | "JSX"
   | "TypeScript"
   | "Dts"

--- a/src/native_loader.ts
+++ b/src/native_loader.ts
@@ -48,6 +48,7 @@ async function loadFromCLI(
   let loader: esbuild.Loader;
   switch (module.mediaType) {
     case "JavaScript":
+    case "Mjs":
       loader = "js";
       break;
     case "JSX":


### PR DESCRIPTION
An error occurs when loading file with .mjs extension.
It seems that .mjs file is included in deno_std/node after v0.127.0 https://deno.land/std@0.127.0/node/process.ts

<img width="501" alt="image" src="https://user-images.githubusercontent.com/49385012/160069454-e16fea0e-2127-4aa4-a75d-df2c9f64ba3e.png">

So I fixed the issue by adding mediaType and handling logic.

resolves #6 