### PR TITLE
fix: support .json

### DIFF
--- a/src/native_loader.ts
+++ b/src/native_loader.ts
@@ -69,6 +69,9 @@ async function loadFromCLI(
     case "TSX":
       loader = "tsx";
       break;
+    case 'Json':
+      loader = 'json';
+      break;
     default:
       throw new Error(`Unhandled media type ${module.mediaType}.`);
   }

--- a/src/portable_loader.ts
+++ b/src/portable_loader.ts
@@ -72,6 +72,8 @@ function mapContentTypeToLoader(
       return "ts";
     case "TSX":
       return "tsx";
+    case "Json":
+      return "json";
     default:
       throw new Error(
         `Unhandled media type ${mediaType}. Content type is ${contentType}.`,
@@ -134,6 +136,8 @@ function mapJsLikeExtension(
       return "Cjs";
     case ".tsx":
       return "TSX";
+    case ".json":
+      return "Json";
     case ".ts":
       if (path.endsWith(".d.ts")) {
         return "Dts";


### PR DESCRIPTION
Was getting this error importing json, despite esbuild [having a built-in json loader](https://esbuild.github.io/content-types/#json).  So I just added the mapping in the switch statements.

<img width="671" alt="Screen Shot 2022-06-11 at 5 13 07 PM" src="https://user-images.githubusercontent.com/8182843/173209031-abc0b741-9e6f-4eec-9a7e-49afb00c4123.png">
