### PR TITLE
use esbuild 0.14.48 for FreeBSD compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Deno module resolution for `esbuild`.
 This example bundles an entrypoint into a single ESM output.
 
 ```js
-import * as esbuild from "https://deno.land/x/esbuild@v0.14.39/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.14.48/mod.js";
 import { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.5.0/mod.ts";
 
 await esbuild.build({

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-import type * as esbuild from "https://deno.land/x/esbuild@v0.14.39/mod.d.ts";
+import type * as esbuild from "https://deno.land/x/esbuild@v0.14.48/mod.d.ts";
 export type { esbuild };
 export {
   fromFileUrl,

--- a/examples/bundle.ts
+++ b/examples/bundle.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.14.39/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.14.48/mod.js";
 import { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.5.0/mod.ts";
 
 await esbuild.build({

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.14.39/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.14.48/mod.js";
 export { esbuild };
 export {
   assert,


### PR DESCRIPTION
esbuild 0.14.48 adds some FreeBSD support in Deno land.
Tests seem to pass with these modification on FreeBSD 13.1-RELEASE with Deno 1.23.1 installed.