### PR TITLE
feat: enable capturing some file paths by other plugins

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -25,14 +25,23 @@ export interface DenoPluginOptions {
    *                 Requires --allow-net.
    */
   loader?: "native" | "portable";
+  /**
+   * Specify regex for the import paths this plugin should resolve. By default,
+   * it will capture all file paths and throw when a path is not recognised.
+   */
+  filter?: RegExp;
 }
 
 /** The default loader to use. */
 export const DEFAULT_LOADER: "native" | "portable" =
   typeof Deno.run === "function" ? "native" : "portable";
 
+/** By default, capture all paths. */
+export const DEFAULT_FILTER = /.*/;
+
 export function denoPlugin(options: DenoPluginOptions = {}): esbuild.Plugin {
   const loader = options.loader ?? DEFAULT_LOADER;
+  const filter = options.filter ?? DEFAULT_FILTER;
   return {
     name: "deno",
     setup(build) {
@@ -49,7 +58,7 @@ export function denoPlugin(options: DenoPluginOptions = {}): esbuild.Plugin {
         }
       });
 
-      build.onResolve({ filter: /.*/ }, function onResolve(
+      build.onResolve({ filter }, function onResolve(
         args: esbuild.OnResolveArgs,
       ): esbuild.OnResolveResult | null | undefined {
         const resolveDir = args.resolveDir
@@ -70,7 +79,7 @@ export function denoPlugin(options: DenoPluginOptions = {}): esbuild.Plugin {
         return { path: resolved.href, namespace: "deno" };
       });
 
-      build.onLoad({ filter: /.*/ }, function onLoad(
+      build.onLoad({ filter }, function onLoad(
         args: esbuild.OnLoadArgs,
       ): Promise<esbuild.OnLoadResult | null> {
         const url = new URL(args.path);


### PR DESCRIPTION
**Context**

This is probably my first open source PR, please be gentle :-)

At the moment, this plugin captures all Deno imports in esbuild. This means that another plugin cannot capture files with a specific extension to load them in.

Initially I thought let's hard code the extensions that the plugin captures, but then it occured to me that this could be a breaking change. I designed this PR to not introduce any breaking changes, and as such the PR does not change the behaviour of capturing every file path by default. To use the plugin with this PR, someone could provide a `fitler` option with a custom filter regex to esbuild, that replaces the default `/.*/`.

**Pitfalls**

The approach of leaving `/.*/` as a default filter means that if someone wants to use another plugin alongside this one, they have to construct their own regex expression to exclude a specific file extension from this plugin.