### PR TITLE
fix: use 'deno' from path if Deno.execPath() doesn't return a deno ex…

### DIFF
--- a/src/deno.ts
+++ b/src/deno.ts
@@ -44,8 +44,9 @@ export async function info(
   specifier: URL,
   options: DenoInfoOptions,
 ): Promise<InfoOutput> {
+  const denoExecPath = Deno.execPath() 
   const cmd = [
-    Deno.execPath().endsWith('deno.exe') ? Deno.execPath() : 'deno',
+    denoExecPath.endsWith('deno.exe') || denoExecPath.endsWith('deno') ? denoExecPath : 'deno',
     "info",
     "--json",
   ];

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -45,7 +45,7 @@ export async function info(
   options: DenoInfoOptions,
 ): Promise<InfoOutput> {
   const cmd = [
-    Deno.execPath(),
+    Deno.execPath().endsWith('deno.exe') ? Deno.execPath() : 'deno',
     "info",
     "--json",
   ];


### PR DESCRIPTION
fixes #26 

The solution is pretty simple as it justs assumes that if `Deno.execPath()` doesn't return a path that ends with `deno.exe` (i.e. we assume `deno compile` was used) that we should use `deno` from path. This should work in most cases, but if deno isn't on the path it will also fail, but I'm not aware of a method to find the executable if it's not on path. 