### PR TITLE
Add support for file loading for WASM builds

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -99,7 +99,7 @@ export function denoPlugin(options: DenoPluginOptions = {}): esbuild.Plugin {
             return portableLoad(url, options);
         }
       }
-      build.onLoad({ filter: /.*\.json/, namespace: "file" }, onLoad);
+      build.onLoad({ filter: /.*/, namespace: "file" }, onLoad);
       build.onLoad({ filter: /.*/, namespace: "http" }, onLoad);
       build.onLoad({ filter: /.*/, namespace: "https" }, onLoad);
       build.onLoad({ filter: /.*/, namespace: "data" }, onLoad);


### PR DESCRIPTION
Test case:

mod.ts
```ts
import { build } from "https://deno.land/x/esbuild@v0.17.10/wasm.js";
import { denoPlugin } from "https://deno.land/x/esbuild_deno_loader@0.6.0/mod.ts";

await build({
  entryPoints: [new URL("./test.ts", import.meta.url).href],
  format: "esm",
  bundle: true,
  plugins: [denoPlugin()],
});
console.log("Success");
```

test.ts
```ts
console.log("Hello, world");
```

run.sh
```bash
deno run -A mod.ts
```

Output before change:
```
✘ [ERROR] Cannot read file "dir/test.ts": not implemented on js

error: Uncaught (in promise) Error: Build failed with 1 error:
error: Cannot read file "dir/test.ts": not implemented on js
  let error = new Error(`${text}${summary}`);
              ^
    at failureErrorWithLog (https://deno.land/x/esbuild@v0.17.10/wasm.js:1612:15)
    at https://deno.land/x/esbuild@v0.17.10/wasm.js:1024:25
    at runOnEndCallbacks (https://deno.land/x/esbuild@v0.17.10/wasm.js:1447:45)
    at buildResponseToResult (https://deno.land/x/esbuild@v0.17.10/wasm.js:1022:7)
    at https://deno.land/x/esbuild@v0.17.10/wasm.js:1051:16
    at responseCallbacks.<computed> (https://deno.land/x/esbuild@v0.17.10/wasm.js:673:9)
    at handleIncomingPacket (https://deno.land/x/esbuild@v0.17.10/wasm.js:728:9)
    at readFromStdout (https://deno.land/x/esbuild@v0.17.10/wasm.js:649:7)
    at Worker.worker.onmessage (https://deno.land/x/esbuild@v0.17.10/wasm.js:1777:38)
    at Worker.wrappedHandler (internal:deno_web/02_event.js:1396:12)
```

Output after change:
```
Success
```