### PR TITLE
fix: file access on esbuild-wasm

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -98,7 +98,9 @@ export function denoPlugin(options: DenoPluginOptions = {}): esbuild.Plugin {
             return portableLoad(url, options);
         }
       }
-      build.onLoad({ filter: /.*\.json/, namespace: "file" }, onLoad);
+      // TODO(lucacasonato): once https://github.com/evanw/esbuild/pull/2968 is fixed, remove the catch all "file" handler
+      // build.onLoad({ filter: /.*\.json/, namespace: "file" }, onLoad);
+      build.onLoad({ filter: /.*/, namespace: "file" }, onLoad);
       build.onLoad({ filter: /.*/, namespace: "http" }, onLoad);
       build.onLoad({ filter: /.*/, namespace: "https" }, onLoad);
       build.onLoad({ filter: /.*/, namespace: "data" }, onLoad);

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,5 +1,6 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.17.11/mod.js";
-export { esbuild };
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.17.11/mod.js";
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.11/wasm.js";
+export { esbuildNative, esbuildWasm };
 export {
   assert,
   assertEquals,


### PR DESCRIPTION
This is a temporary fix for file loading on WASM. It will ultimately be
fixed by https://github.com/evanw/esbuild/pull/2968.

This commit also improves the test suite to run all tests in both native
and wasm versions of esbuild.

Inspired by #38