### PR TITLE
feat: support npm specifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 deno.lock
 dist/
+node_modules/
+dist/

--- a/deps.ts
+++ b/deps.ts
@@ -2,6 +2,7 @@ import type * as esbuild from "https://deno.land/x/esbuild@v0.17.11/mod.d.ts";
 export type { esbuild };
 export {
   fromFileUrl,
+  join,
   resolve,
   toFileUrl,
 } from "https://deno.land/std@0.173.0/path/mod.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -51,10 +51,31 @@ export interface DenoPluginsOptions {
    * determine what import map to use, if any.
    */
   importMapURL?: string;
+  /**
+   * Specify a working directory to use.
+   *
+   * When using the `native` loader with the `nodeModulesDir` option set to
+   * true, this directory is where the generated `node_modules` dir will be
+   * placed.
+   *
+   * When using the `portable` loader, this is the directory that will be used
+   * as the starting point for searching for node modules in a `node_modules`
+   * directory.
+   */
+  cwd?: string;
+  /**
+   * Specify whether to generate and use a local `node_modules` directory when
+   * using the `native` loader. This is equivalent to the `--node-modules-dir`
+   * flag to the Deno executable.
+   *
+   * This option is ignored when using the `portable` loader, as the portable
+   * loader always uses a local `node_modules` directory.
+   */
+  nodeModulesDir?: boolean;
 }
 
 export function denoPlugins(
-  opts: DenoLoaderPluginOptions = {},
+  opts: DenoPluginsOptions = {},
 ): esbuild.Plugin[] {
   return [
     denoResolverPlugin(opts),

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -55,6 +55,7 @@ test("remote ts", LOADERS, async (esbuild, loader) => {
   });
   assertEquals(res.warnings, []);
   assertEquals(res.errors, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -70,6 +71,7 @@ test("local ts", LOADERS, async (esbuild, loader) => {
     entryPoints: ["./testdata/mod.ts"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
@@ -280,6 +282,44 @@ test("local json", LOADERS, async (esbuild, loader) => {
       "sky": "universe",
     },
   });
+});
+
+test("npm specifiers - preact", LOADERS, async (esbuild, loader) => {
+  const res = await esbuild.build({
+    plugins: [...denoPlugins({ loader, cwd: Deno.cwd(), nodeModulesDir: true })],
+    write: false,
+    format: "esm",
+    bundle: true,
+    entryPoints: ["./testdata/npm/preact.tsx"],
+  });
+  assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
+  assertEquals(res.outputFiles.length, 1);
+  const output = res.outputFiles[0];
+  assertEquals(output.path, "<stdout>");
+  assert(!output.text.includes(`npm:`));
+  const dataURL = `data:application/javascript;base64,${btoa(output.text)}`;
+  const { default: html } = await import(dataURL);
+  assertEquals(html, "<div>hello world</div>");
+});
+
+test("npm specifiers - react", LOADERS, async (esbuild, loader) => {
+  const res = await esbuild.build({
+    plugins: [...denoPlugins({ loader, cwd: Deno.cwd(), nodeModulesDir: true })],
+    write: false,
+    format: "esm",
+    bundle: true,
+    entryPoints: ["./testdata/npm/react.tsx"],
+  });
+  assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
+  assertEquals(res.outputFiles.length, 1);
+  const output = res.outputFiles[0];
+  assertEquals(output.path, "<stdout>");
+  assert(!output.text.includes(`npm:`));
+  const dataURL = `data:application/javascript;base64,${btoa(output.text)}`;
+  const { default: html } = await import(dataURL);
+  assertEquals(html, "<div>hello world</div>");
 });
 
 test("remote http redirects are de-duped", LOADERS, async (esbuild, loader) => {

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -69,6 +69,7 @@ export interface InfoOptions {
   config?: string;
   importMap?: string;
   lock?: string;
+  nodeModulesDir?: boolean;
 }
 
 let tmpDir: string | undefined;
@@ -98,6 +99,9 @@ async function info(
   // } else if (!options.cwd) {
   //   opts.args.push("--no-lock");
   // }
+  if (options.nodeModulesDir) {
+    opts.args.push("--node-modules-dir");
+  }
   if (options.cwd) {
     opts.cwd = options.cwd;
   } else {

--- a/src/loader_portable.ts
+++ b/src/loader_portable.ts
@@ -4,6 +4,7 @@ import {
   Loader,
   LoaderResolution,
   mediaTypeToLoader,
+  parseNpmSpecifier,
   transformRawIntoContent,
 } from "./shared.ts";
 
@@ -29,6 +30,17 @@ export class PortableLoader implements Loader {
       case "data:": {
         const module = await this.#loadRemote(specifier.href);
         return { kind: "esm", specifier: new URL(module.specifier) };
+      }
+      case "npm:": {
+        const npmSpecifier = parseNpmSpecifier(specifier);
+        return {
+          kind: "npm",
+          packageName: npmSpecifier.name,
+          path: npmSpecifier.path ?? "",
+        };
+      }
+      case "node:": {
+        return { kind: "node", path: specifier.pathname };
       }
       default:
         throw new Error(`Unsupported scheme: '${specifier.protocol}'`);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -6,11 +6,25 @@ export interface Loader {
   loadEsm(specifier: URL): Promise<esbuild.OnLoadResult>;
 }
 
-export type LoaderResolution = LoaderResolutionEsm;
+export type LoaderResolution =
+  | LoaderResolutionEsm
+  | LoaderResolutionNpm
+  | LoaderResolutionNode;
 
 export interface LoaderResolutionEsm {
   kind: "esm";
   specifier: URL;
+}
+
+export interface LoaderResolutionNpm {
+  kind: "npm";
+  packageName: string;
+  path: string;
+}
+
+export interface LoaderResolutionNode {
+  kind: "node";
+  path: string;
 }
 
 export function mediaTypeToLoader(mediaType: MediaType): esbuild.Loader {
@@ -108,4 +122,48 @@ export async function readDenoConfig(path: string): Promise<DenoConfig> {
     throw new Error(`Deno config at ${path} has invalid "importMap" key`);
   }
   return res;
+}
+
+export interface NpmSpecifier {
+  name: string;
+  version: string | null;
+  path: string | null;
+}
+
+export function parseNpmSpecifier(specifier: URL): NpmSpecifier {
+  if (specifier.protocol !== "npm:") throw new Error("Invalid npm specifier");
+  const path = specifier.pathname;
+  const startIndex = path[0] === "/" ? 1 : 0;
+  let pathStartIndex;
+  let versionStartIndex;
+  if (path[startIndex] === "@") {
+    const firstSlash = path.indexOf("/", startIndex);
+    if (firstSlash === -1) {
+      throw new Error(`Invalid npm specifier: ${specifier}`);
+    }
+    pathStartIndex = path.indexOf("/", firstSlash + 1);
+    versionStartIndex = path.indexOf("@", firstSlash + 1);
+  } else {
+    pathStartIndex = path.indexOf("/", startIndex);
+    versionStartIndex = path.indexOf("@", startIndex);
+  }
+
+  if (pathStartIndex === -1) pathStartIndex = path.length;
+  if (versionStartIndex === -1) versionStartIndex = path.length;
+
+  if (versionStartIndex > pathStartIndex) {
+    versionStartIndex = pathStartIndex;
+  }
+
+  if (startIndex === versionStartIndex) {
+    throw new Error(`Invalid npm specifier: ${specifier}`);
+  }
+
+  return {
+    name: path.slice(startIndex, versionStartIndex),
+    version: versionStartIndex === pathStartIndex
+      ? null
+      : path.slice(versionStartIndex + 1, pathStartIndex),
+    path: pathStartIndex === path.length ? null : path.slice(pathStartIndex),
+  };
 }

--- a/src/shared_test.ts
+++ b/src/shared_test.ts
@@ -1,0 +1,113 @@
+import { NpmSpecifier, parseNpmSpecifier } from "./shared.ts";
+import { assertEquals, assertThrows } from "../test_deps.ts";
+
+interface NpmSpecifierTestCase extends NpmSpecifier {
+  specifier: string;
+}
+
+const NPM_SPECIFIER_VALID: Array<NpmSpecifierTestCase> = [
+  {
+    specifier: "npm:package@1.2.3/test",
+    name: "package",
+    version: "1.2.3",
+    path: "/test",
+  },
+  {
+    specifier: "npm:package@1.2.3",
+    name: "package",
+    version: "1.2.3",
+    path: null,
+  },
+  {
+    specifier: "npm:@package/test",
+    name: "@package/test",
+    version: null,
+    path: null,
+  },
+  {
+    specifier: "npm:@package/test@1",
+    name: "@package/test",
+    version: "1",
+    path: null,
+  },
+  {
+    specifier: "npm:@package/test@~1.1/sub_path",
+    name: "@package/test",
+    version: "~1.1",
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:@package/test/sub_path",
+    name: "@package/test",
+    version: null,
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:test",
+    name: "test",
+    version: null,
+    path: null,
+  },
+  {
+    specifier: "npm:test@^1.2",
+    name: "test",
+    version: "^1.2",
+    path: null,
+  },
+  {
+    specifier: "npm:test@~1.1/sub_path",
+    name: "test",
+    version: "~1.1",
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:@package/test/sub_path",
+    name: "@package/test",
+    version: null,
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:/@package/test/sub_path",
+    name: "@package/test",
+    version: null,
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:/test",
+    name: "test",
+    version: null,
+    path: null,
+  },
+  {
+    specifier: "npm:/test/",
+    name: "test",
+    version: null,
+    path: "/",
+  },
+];
+
+for (const test of NPM_SPECIFIER_VALID) {
+  Deno.test(`parseNpmSpecifier: ${test.specifier}`, () => {
+    const parsed = parseNpmSpecifier(new URL(test.specifier));
+    assertEquals(parsed, {
+      name: test.name,
+      version: test.version,
+      path: test.path,
+    });
+  });
+}
+
+const NPM_SPECIFIER_INVALID = [
+  "npm:@package",
+  "npm:/",
+  "npm://test",
+];
+for (const specifier of NPM_SPECIFIER_INVALID) {
+  Deno.test(`parseNpmSpecifier: ${specifier}`, () => {
+    assertThrows(
+      () => parseNpmSpecifier(new URL(specifier)),
+      Error,
+      "Invalid npm specifier",
+    );
+  });
+}

--- a/testdata/npm/preact.tsx
+++ b/testdata/npm/preact.tsx
@@ -1,0 +1,5 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource npm:preact */
+import { renderToString } from "npm:preact-render-to-string";
+
+export default renderToString(<div>hello world</div>);

--- a/testdata/npm/react.tsx
+++ b/testdata/npm/react.tsx
@@ -1,0 +1,5 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource npm:react */
+import { renderToString } from "npm:react-dom/server";
+
+export default renderToString(<div>hello world</div>);


### PR DESCRIPTION
This commit adds support for NPM specifiers. There is the caveat that
the code must previously have been cached and a local `node_modules` dir
generated with a command like `deno cache --node-modules-dir`.

Closes #29
