### PR TITLE
fix: proper redirect handling in loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 deno.lock
+dist/

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -28,6 +28,7 @@ test("remote ts", ALL, async (loader) => {
     entryPoints: ["https://deno.land/std@0.173.0/collections/without_all.ts"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -43,6 +44,7 @@ test("local ts", ALL, async (loader) => {
     entryPoints: ["./testdata/mod.ts"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -60,6 +62,7 @@ test("remote mts", ALL, async (loader) => {
     ],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -75,6 +78,7 @@ test("local mts", ALL, async (loader) => {
     entryPoints: ["./testdata/mod.mts"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -90,6 +94,7 @@ test("remote js", ALL, async (loader) => {
     entryPoints: ["https://crux.land/266TSp"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -105,6 +110,7 @@ test("local js", ALL, async (loader) => {
     entryPoints: ["./testdata/mod.js"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -122,6 +128,7 @@ test("remote mjs", ALL, async (loader) => {
     ],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -137,6 +144,7 @@ test("local mjs", ALL, async (loader) => {
     entryPoints: ["./testdata/mod.mjs"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -152,6 +160,7 @@ test("remote jsx", ALL, async (loader) => {
     entryPoints: ["https://crux.land/GeaWJ"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -167,6 +176,7 @@ test("local jsx", ALL, async (loader) => {
     entryPoints: ["./testdata/mod.jsx"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -182,6 +192,7 @@ test("remote tsx", ALL, async (loader) => {
     entryPoints: ["https://crux.land/2Qjyo7"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -197,6 +208,7 @@ test("local tsx", ALL, async (loader) => {
     entryPoints: ["./testdata/mod.tsx"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -214,6 +226,7 @@ test("bundle remote imports", ALL, async (loader) => {
     entryPoints: ["https://deno.land/std@0.173.0/uuid/mod.ts"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -235,6 +248,7 @@ test("bundle import map", ALL, async (loader) => {
     entryPoints: ["./testdata/importmap.js"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -251,6 +265,7 @@ test("local json", ALL, async (loader) => {
     entryPoints: ["./testdata/data.json"],
   });
   assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
   assertEquals(res.outputFiles.length, 1);
   const output = res.outputFiles[0];
   assertEquals(output.path, "<stdout>");
@@ -262,4 +277,21 @@ test("local json", ALL, async (loader) => {
       "sky": "universe",
     },
   });
+});
+
+test("remote http redirects are de-duped", ALL, async (loader) => {
+  const res = await esbuild.build({
+    plugins: [denoPlugin({ loader })],
+    write: false,
+    bundle: true,
+    format: "esm",
+    entryPoints: ["./testdata/remote_redirects.js"],
+  });
+  assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
+  assertEquals(res.outputFiles.length, 1);
+  const output = res.outputFiles[0];
+  assertEquals(output.path, "<stdout>");
+  const matches = [...output.text.matchAll(/0\.178\.0/g)];
+  assertEquals(matches.length, 2); // once in the comment, once in the code
 });

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -17,55 +17,137 @@ export type MediaType =
   | "SourceMap"
   | "Unknown";
 
-export interface InfoOutput {
+interface InfoOutput {
   roots: string[];
   modules: ModuleEntry[];
   redirects: Record<string, string>;
 }
 
-export interface ModuleEntry {
+export type ModuleEntry =
+  | ModuleEntryError
+  | ModuleEntryEsm
+  | ModuleEntryJson
+  | ModuleEntryNpm
+  | ModuleEntryNode;
+
+export interface ModuleEntryBase {
   specifier: string;
-  size: number;
-  mediaType?: MediaType;
-  local?: string;
-  checksum?: string;
-  emit?: string;
-  map?: string;
-  error?: string;
 }
 
-interface DenoInfoOptions {
+export interface ModuleEntryError extends ModuleEntryBase {
+  error: string;
+}
+
+export interface ModuleEntryEsm extends ModuleEntryBase {
+  kind: "esm";
+  local: string | null;
+  emit: string | null;
+  map: string | null;
+  mediaType: MediaType;
+  size: number;
+}
+
+export interface ModuleEntryJson extends ModuleEntryBase {
+  kind: "asserted" | "json";
+  local: string | null;
+  mediaType: MediaType;
+  size: number;
+}
+
+export interface ModuleEntryNpm extends ModuleEntryBase {
+  kind: "npm";
+  npmPackage: string;
+}
+
+export interface ModuleEntryNode extends ModuleEntryBase {
+  kind: "node";
+  moduleName: string;
+}
+
+interface InfoOptions {
   importMap?: string;
 }
 
-let tempDir: null | string;
-
-export async function info(
-  specifier: URL,
-  options: DenoInfoOptions,
+async function info(
+  specifier: string,
+  options: InfoOptions,
 ): Promise<InfoOutput> {
   const args = [
     "info",
     "--json",
+    "--node-modules-dir",
+    "--no-config",
   ];
   if (options.importMap !== undefined) {
     args.push("--import-map", options.importMap);
   }
-  args.push(specifier.href);
-
-  if (!tempDir) {
-    tempDir = Deno.makeTempDirSync();
-  }
+  args.push(specifier);
 
   const output = await new Deno.Command(Deno.execPath(), {
     args,
-    cwd: tempDir,
+    env: {
+      DENO_NO_PACKAGE_JSON: "true",
+    },
     stdout: "piped",
     stderr: "inherit",
   }).output();
   if (!output.success) {
-    throw new Error(`Failed to call 'deno info' on '${specifier.href}'`);
+    throw new Error(`Failed to call 'deno info' on '${specifier}'`);
   }
   const txt = new TextDecoder().decode(output.stdout);
   return JSON.parse(txt);
+}
+
+export class InfoCache {
+  #options: InfoOptions;
+
+  #modules: Map<string, ModuleEntry> = new Map();
+  #redirects: Map<string, string> = new Map();
+
+  constructor(options: InfoOptions) {
+    this.#options = options;
+  }
+
+  async get(specifier: string): Promise<ModuleEntry> {
+    let entry = this.#getCached(specifier);
+    if (entry !== undefined) return entry;
+
+    await this.#load(specifier);
+
+    entry = this.#getCached(specifier);
+    if (entry === undefined) {
+      throw new Error(`Unreachable: '${specifier}' loaded but not reachable`);
+    }
+
+    return entry;
+  }
+
+  #resolve(specifier: string): string {
+    return this.#redirects.get(specifier) ?? specifier;
+  }
+
+  #getCached(specifier: string): ModuleEntry | undefined {
+    specifier = this.#resolve(specifier);
+    return this.#modules.get(specifier);
+  }
+
+  async #load(specifier: string): Promise<void> {
+    const { modules, redirects } = await info(specifier, {
+      importMap: this.#options.importMap,
+    });
+    for (const module of modules) {
+      this.#modules.set(module.specifier, module);
+    }
+    for (const [from, to] of Object.entries(redirects)) {
+      this.#redirects.set(from, to);
+    }
+
+    specifier = this.#resolve(specifier);
+    const entry = this.#modules.get(specifier);
+    if (entry === undefined) {
+      // we hit https://github.com/denoland/deno/issues/18043, so we have to
+      // perform another load to get the actual data of the redirected specifier
+      await this.#load(specifier);
+    }
+  }
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,6 +1,22 @@
 import { esbuild } from "../deps.ts";
 import { MediaType } from "./deno.ts";
 
+export interface Loader {
+  resolve(specifier: URL): Promise<LoaderResolution>;
+  loadEsm(specifier: string): Promise<esbuild.OnLoadResult>;
+}
+
+export type LoaderResolution = LoaderResolutionEsm;
+
+export interface LoaderResolutionEsm {
+  kind: "esm";
+  specifier: URL;
+}
+
+export interface LoaderOptions {
+  importMapURL?: URL;
+}
+
 export function mediaTypeToLoader(mediaType: MediaType): esbuild.Loader {
   switch (mediaType) {
     case "JavaScript":

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -3,4 +3,5 @@ export { esbuild };
 export {
   assert,
   assertEquals,
+  assertThrows,
 } from "https://deno.land/std@0.173.0/testing/asserts.ts";

--- a/testdata/remote_redirects.js
+++ b/testdata/remote_redirects.js
@@ -1,0 +1,3 @@
+import { VERSION as A } from "https://deno.land/std@0.178.0/version.ts";
+import { VERSION as B } from "https://deno.land/x/std@0.178.0/version.ts";
+export { A, B };


### PR DESCRIPTION
This commit refactors how loaders work. They now take part in
resolving, which allows them to handle redirected HTTP specifiers
correctly. Previously redirects were not handled at all - leading to
duplicated dependencies in some cases.
