### PR TITLE
fix(plugin_deno_resolver.ts): esbuild on stdin fails because referrer…

### DIFF
--- a/src/plugin_deno_resolver.ts
+++ b/src/plugin_deno_resolver.ts
@@ -105,7 +105,9 @@ export function denoResolverPlugin(
           const res = resolveModuleSpecifier(
             args.path,
             importMap,
-            new URL(referrer) || undefined,
+            args.importer.includes("<stdin>")
+              ? new URL(import.meta.url)
+              : new URL(referrer) || undefined,
           );
           resolved = new URL(res);
         } else {


### PR DESCRIPTION
… is not a valid url

Esbuild on stdin fails because referrer is not a valid url