### PR TITLE
fix: fix warning in resolveImportMap, by not passing additional keys in the ImportMap

### DIFF
--- a/src/plugin_deno_resolver.ts
+++ b/src/plugin_deno_resolver.ts
@@ -55,9 +55,12 @@ export function denoResolverPlugin(
           // If `imports` or `scopes` are specified, use the config file as the
           // import map directly.
           if (config.imports !== undefined || config.scopes !== undefined) {
+            const configImportMap = {
+              imports: config.imports,
+              scopes: config.scopes,
+            } as ImportMap;
             importMap = resolveImportMap(
-              // deno-lint-ignore no-explicit-any
-              config as any,
+              configImportMap,
               toFileUrl(options.configPath),
             );
           } else if (config.importMap !== undefined) {


### PR DESCRIPTION
Otherwise the following warning will be logged:
`an invalid top-level key was present in the import map.`