### PR TITLE
feat: support for `npm:` specifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: deno lint
 
       - name: Run tests
-        run: deno task test
+        run: deno test -A

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 deno.lock
 dist/
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Deno module resolution for `esbuild`.
 
+- Support for `file:`, `https:`, and `data:` specifiers
+- Support for `npm:` specifiers
+- Support for import maps (including embedded into `deno.json`)
+- Native loader using Deno's global cache directory
+- Portable loader that words in environments with limited permissions
+
 ## Example
 
 This example bundles an entrypoint into a single ESM output.
@@ -25,6 +31,15 @@ console.log(result.outputFiles);
 
 esbuild.stop();
 ```
+
+## Limitations
+
+- The `"portable"` loader does not use the Deno module cache, so all remote
+  specifiers are downloaded on every run.
+- When using the `"portable"` loader, all `npm:` dependencies must be
+  pre-downloaded into a local `node_modules/` directory.
+- `npm:` specifiers are not supported on WASM esbuild builds due to FS access
+  limitations (see https://github.com/evanw/esbuild/pull/2968).
 
 ## Documentation
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,9 +1,0 @@
-{
-  "tasks": {
-    "test": "deno test -A",
-    "update": "deno run --allow-read=./ --allow-net --allow-write=./ https://deno.land/x/deno_outdated@0.2.4/cli.ts"
-  },
-  "imports": {
-    "a": "https://deno.land/x/a/mod.ts"
-  }
-}

--- a/deps.ts
+++ b/deps.ts
@@ -1,12 +1,16 @@
 import type * as esbuild from "https://deno.land/x/esbuild@v0.17.18/mod.d.ts";
 export type { esbuild };
 export {
+  dirname,
   fromFileUrl,
+  join,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.185.0/path/mod.ts";
-export { basename, extname } from "https://deno.land/std@0.185.0/path/mod.ts";
-export * as JSONC from "https://deno.land/std@0.185.0/jsonc/mod.ts";
+} from "https://deno.land/std@0.173.0/path/mod.ts";
+export { copy } from "https://deno.land/std@0.173.0/fs/mod.ts";
+export { basename, extname } from "https://deno.land/std@0.173.0/path/mod.ts";
+export * as JSONC from "https://deno.land/std@0.173.0/encoding/jsonc.ts";
+export { encode as base32Encode } from "https://deno.land/std@0.173.0/encoding/base32.ts";
 export {
   resolveImportMap,
   resolveModuleSpecifier,
@@ -16,3 +20,4 @@ export type {
   Scopes,
   SpecifierMap,
 } from "https://deno.land/x/importmap@0.2.1/mod.ts";
+export { DenoDir } from "https://deno.land/x/deno_cache@0.4.1/mod.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -51,6 +51,15 @@ export interface DenoPluginsOptions {
    * determine what import map to use, if any.
    */
   importMapURL?: string;
+  /**
+   * Specify whether to generate and use a local `node_modules` directory when
+   * using the `native` loader. This is equivalent to the `--node-modules-dir`
+   * flag to the Deno executable.
+   *
+   * This option is ignored when using the `portable` loader, as the portable
+   * loader always uses a local `node_modules` directory.
+   */
+  nodeModulesDir?: boolean;
 }
 
 export function denoPlugins(opts: DenoPluginsOptions = {}): esbuild.Plugin[] {

--- a/src/loader_portable.ts
+++ b/src/loader_portable.ts
@@ -5,6 +5,7 @@ import {
   LoaderResolution,
   mapContentType,
   mediaTypeToLoader,
+  parseNpmSpecifier,
 } from "./shared.ts";
 
 interface Module {
@@ -29,6 +30,18 @@ export class PortableLoader implements Loader {
       case "data:": {
         const module = await this.#loadRemote(specifier.href);
         return { kind: "esm", specifier: new URL(module.specifier) };
+      }
+      case "npm:": {
+        const npmSpecifier = parseNpmSpecifier(specifier);
+        return {
+          kind: "npm",
+          packageId: "",
+          packageName: npmSpecifier.name,
+          path: npmSpecifier.path ?? "",
+        };
+      }
+      case "node:": {
+        return { kind: "node", path: specifier.pathname };
       }
       default:
         throw new Error(`Unsupported scheme: '${specifier.protocol}'`);

--- a/src/plugin_deno_resolver.ts
+++ b/src/plugin_deno_resolver.ts
@@ -28,6 +28,9 @@ export interface DenoResolverPluginOptions {
   importMapURL?: string;
 }
 
+export const IN_NODE_MODULES = Symbol("IN_NODE_MODULES");
+export const IN_NODE_MODULES_RESOLVED = Symbol("IN_NODE_MODULES_RESOLVED");
+
 /**
  * The Deno resolver plugin performs relative->absolute specifier resolution
  * and import map resolution.
@@ -42,8 +45,11 @@ export function denoResolverPlugin(
     name: "deno-resolver",
     setup(build) {
       let importMap: ImportMap | null = null;
+      let nodeModulesPaths: Set<string>;
 
       build.onStart(async function onStart() {
+        nodeModulesPaths = new Set<string>();
+
         let importMapURL: string | undefined;
 
         // If no import map URL is specified, and a config is specified, we try
@@ -81,6 +87,24 @@ export function denoResolverPlugin(
       });
 
       build.onResolve({ filter: /.*/ }, async function onResolve(args) {
+        // If this is a node_modules internal resolution, just pass it through.
+        // Internal resolution is detected by either the "IN_NODE_MODULES" flag
+        // being set on the resolve args through the pluginData field, or by
+        // the importer being in the nodeModulesPaths set.
+        if (args.pluginData === IN_NODE_MODULES_RESOLVED) return {};
+        if (args.pluginData === IN_NODE_MODULES) return undefined;
+        if (nodeModulesPaths.has(args.importer)) {
+          const res = await build.resolve(args.path, {
+            importer: args.importer,
+            namespace: args.namespace,
+            kind: args.kind,
+            resolveDir: args.resolveDir,
+            pluginData: IN_NODE_MODULES,
+          });
+          if (!res.external) nodeModulesPaths.add(res.path);
+          return res;
+        }
+
         // The first pass resolver performs synchronous resolution. This
         // includes relative to absolute specifier resolution and import map
         // resolution.
@@ -108,7 +132,7 @@ export function denoResolverPlugin(
           const res = resolveModuleSpecifier(
             args.path,
             importMap,
-            new URL(referrer) || undefined,
+            new URL(referrer),
           );
           resolved = new URL(res);
         } else {
@@ -119,10 +143,12 @@ export function denoResolverPlugin(
         // pass. Now plugins can perform any resolution they want on the fully
         // resolved specifier.
         const { path, namespace } = urlToEsbuildResolution(resolved);
-        return await build.resolve(path, {
+        const res = await build.resolve(path, {
           namespace,
           kind: args.kind,
         });
+        if (res.pluginData === IN_NODE_MODULES) nodeModulesPaths.add(res.path);
+        return res;
       });
     },
   };

--- a/src/shared_test.ts
+++ b/src/shared_test.ts
@@ -1,0 +1,113 @@
+import { NpmSpecifier, parseNpmSpecifier } from "./shared.ts";
+import { assertEquals, assertThrows } from "../test_deps.ts";
+
+interface NpmSpecifierTestCase extends NpmSpecifier {
+  specifier: string;
+}
+
+const NPM_SPECIFIER_VALID: Array<NpmSpecifierTestCase> = [
+  {
+    specifier: "npm:package@1.2.3/test",
+    name: "package",
+    version: "1.2.3",
+    path: "/test",
+  },
+  {
+    specifier: "npm:package@1.2.3",
+    name: "package",
+    version: "1.2.3",
+    path: null,
+  },
+  {
+    specifier: "npm:@package/test",
+    name: "@package/test",
+    version: null,
+    path: null,
+  },
+  {
+    specifier: "npm:@package/test@1",
+    name: "@package/test",
+    version: "1",
+    path: null,
+  },
+  {
+    specifier: "npm:@package/test@~1.1/sub_path",
+    name: "@package/test",
+    version: "~1.1",
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:@package/test/sub_path",
+    name: "@package/test",
+    version: null,
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:test",
+    name: "test",
+    version: null,
+    path: null,
+  },
+  {
+    specifier: "npm:test@^1.2",
+    name: "test",
+    version: "^1.2",
+    path: null,
+  },
+  {
+    specifier: "npm:test@~1.1/sub_path",
+    name: "test",
+    version: "~1.1",
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:@package/test/sub_path",
+    name: "@package/test",
+    version: null,
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:/@package/test/sub_path",
+    name: "@package/test",
+    version: null,
+    path: "/sub_path",
+  },
+  {
+    specifier: "npm:/test",
+    name: "test",
+    version: null,
+    path: null,
+  },
+  {
+    specifier: "npm:/test/",
+    name: "test",
+    version: null,
+    path: "/",
+  },
+];
+
+for (const test of NPM_SPECIFIER_VALID) {
+  Deno.test(`parseNpmSpecifier: ${test.specifier}`, () => {
+    const parsed = parseNpmSpecifier(new URL(test.specifier));
+    assertEquals(parsed, {
+      name: test.name,
+      version: test.version,
+      path: test.path,
+    });
+  });
+}
+
+const NPM_SPECIFIER_INVALID = [
+  "npm:@package",
+  "npm:/",
+  "npm://test",
+];
+for (const specifier of NPM_SPECIFIER_INVALID) {
+  Deno.test(`parseNpmSpecifier: ${specifier}`, () => {
+    assertThrows(
+      () => parseNpmSpecifier(new URL(specifier)),
+      Error,
+      "Invalid npm specifier",
+    );
+  });
+}

--- a/testdata/npm/preact.tsx
+++ b/testdata/npm/preact.tsx
@@ -1,0 +1,5 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource npm:preact */
+import { renderToString } from "npm:preact-render-to-string";
+
+export default renderToString(<div>hello world</div>);

--- a/testdata/npm/react.tsx
+++ b/testdata/npm/react.tsx
@@ -1,0 +1,5 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource npm:react */
+import { renderToString } from "npm:react-dom/server";
+
+export default renderToString(<div>hello world</div>);


### PR DESCRIPTION
This commit adds support for NPM specifiers, when using a native build
of esbuild (not the WASM build!). Both Deno's global resolver (that does
not use node_modules), and the resolver using the local `node_modules/`
folder are supported.

When using the native loader, the global resolver is used by default.
The `nodeModulesDir` option can be used to switch to the local resolver.
When this option is enabled, a `node_modules/` folder is automatically
generated, as if one had passed `--node-modules-dir` to `deno run`.

In the portable loader, the global resolver is unsupported. The
`nodeModulesDir` option MUST be specified here to support `npm:`
resolution. A `node_modules/` directory must have been generated
up-front using `deno cache --node-modules-dir <entrypoint>`, or similar.

Closes #56
Closes #29
