### PR TITLE
fix: stop intercepting JSON loads

### DIFF
--- a/src/loader_portable.ts
+++ b/src/loader_portable.ts
@@ -5,7 +5,6 @@ import {
   LoaderResolution,
   mapContentType,
   mediaTypeToLoader,
-  transformRawIntoContent,
 } from "./shared.ts";
 
 interface Module {
@@ -54,9 +53,8 @@ export class PortableLoader implements Loader {
     }
 
     const loader = mediaTypeToLoader(module.mediaType);
-    const contents = transformRawIntoContent(module.data, module.mediaType);
 
-    const res: esbuild.OnLoadResult = { contents, loader };
+    const res: esbuild.OnLoadResult = { contents: module.data, loader };
     if (url.protocol === "file:") {
       res.watchFiles = [fromFileUrl(module.specifier)];
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -26,29 +26,10 @@ export function mediaTypeToLoader(mediaType: MediaType): esbuild.Loader {
     case "TSX":
       return "tsx";
     case "Json":
-      return "js";
+      return "json";
     default:
       throw new Error(`Unhandled media type ${mediaType}.`);
   }
-}
-
-export function transformRawIntoContent(
-  raw: Uint8Array,
-  mediaType: MediaType,
-): string | Uint8Array {
-  switch (mediaType) {
-    case "Json":
-      return jsonToESM(raw);
-    default:
-      return raw;
-  }
-}
-
-function jsonToESM(source: Uint8Array): string {
-  const sourceString = new TextDecoder().decode(source);
-  let json = JSON.stringify(JSON.parse(sourceString), null, 2);
-  json = json.replaceAll(`"__proto__":`, `["__proto__"]:`);
-  return `export default ${json};`;
 }
 
 export interface EsbuildResolution {


### PR DESCRIPTION
Previously esbuild incorrectly handled JSON imports, transforming them
into something other than a default export of the JSON object. This
is now fixed, so our relevant workaround can be removed!

See https://github.com/evanw/esbuild/commit/b1e737b2e8bd231cd919337ada06c4ca994bd350
