### PR TITLE
feat: set fetch options

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -60,6 +60,11 @@ export interface DenoPluginsOptions {
    * loader always uses a local `node_modules` directory.
    */
   nodeModulesDir?: boolean;
+  /**
+   * Request options to use when fetching remote modules.
+   * This only applies to the `portable` loader.
+   */
+  requestOptions?: RequestInit;
 }
 
 export function denoPlugins(opts: DenoPluginsOptions = {}): esbuild.Plugin[] {

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -577,3 +577,26 @@ test("uncached data url", LOADERS, async (esbuild, loader) => {
   const { value } = await import(dataURL);
   assertEquals(value, rand);
 });
+
+test("browser bundle", ["portable"], async (esbuild, loader) => {
+  const res = await esbuild.build({
+    ...DEFAULT_OPTS,
+    plugins: [
+      ...denoPlugins({
+        loader,
+        requestOptions: { headers: { "User-Agent": "es2022" } },
+      }),
+    ],
+    bundle: true,
+    platform: "neutral",
+    entryPoints: ["./testdata/browser.ts"],
+  });
+  assertEquals(res.warnings, []);
+  assertEquals(res.errors, []);
+  assertEquals(res.outputFiles.length, 1);
+  const output = res.outputFiles[0];
+  assertEquals(output.path, "<stdout>");
+  const dataURL = `data:application/javascript;base64,${btoa(output.text)}`;
+  const { template } = await import(dataURL);
+  assert(template);
+});

--- a/src/loader_portable.ts
+++ b/src/loader_portable.ts
@@ -20,6 +20,12 @@ export class PortableLoader implements Loader {
   #fetchModules = new Map<string, Module>();
   #fetchRedirects = new Map<string, string>();
 
+  #requestOptions: RequestInit | undefined;
+
+  constructor(requestOptions?: RequestInit) {
+    this.#requestOptions = requestOptions;
+  }
+
   async resolve(specifier: URL): Promise<LoaderResolution> {
     switch (specifier.protocol) {
       case "file:": {
@@ -97,9 +103,11 @@ export class PortableLoader implements Loader {
   }
 
   async #fetch(specifier: string): Promise<void> {
-    const resp = await fetch(specifier, {
+    const requestOptions: RequestInit = {
       redirect: "manual",
-    });
+      ...this.#requestOptions,
+    };
+    const resp = await fetch(specifier, requestOptions);
     if (resp.status < 200 && resp.status >= 400) {
       throw new Error(
         `Encountered status code ${resp.status} while fetching ${specifier}.`,

--- a/src/plugin_deno_loader.ts
+++ b/src/plugin_deno_loader.ts
@@ -67,6 +67,11 @@ export interface DenoLoaderPluginOptions {
    * loader always uses a local `node_modules` directory.
    */
   nodeModulesDir?: boolean;
+  /**
+   * Request options to use when fetching remote modules.
+   * This only applies to the `portable` loader.
+   */
+  requestOptions?: RequestInit;
 }
 
 const LOADERS = ["native", "portable"] as const;
@@ -150,7 +155,7 @@ export function denoLoaderPlugin(
             });
             break;
           case "portable":
-            loaderImpl = new PortableLoader();
+            loaderImpl = new PortableLoader(options.requestOptions);
         }
       });
 

--- a/testdata/browser.ts
+++ b/testdata/browser.ts
@@ -1,0 +1,3 @@
+import { template } from "https://esm.sh/solid-js/web";
+
+export { template };


### PR DESCRIPTION
Certain packages export different contents depending on the target platform for compilation. For example, there is a significant difference bundling @solid-js/web for the server versus the client, eg. https://esm.sh/stable/solid-js@1.7.7/deno/web.js & https://esm.sh/stable/solid-js@1.7.7/es2022/web.js.

By allowing users to set the `user-agent` header we can bundle for different targets besides deno. I'm think there could also be other usecases for this, such as bundling authenticated resources etc.

I've gone ahead and passed an RequestInit object from the plugin options to the portable loader. It doesn't seem like it's possible to change how the native loader fetches data though.