### PR TITLE
chore: bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Deno module resolution for `esbuild`.
 This example bundles an entrypoint into a single ESM output.
 
 ```js
-import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.js";
 // Import the WASM build on platforms where running subprocesses is not
 // permitted, such as Deno Deploy, or when running without `--allow-run`.
-// import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/wasm.js";
+// import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/wasm.js";
 
 import { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.1/mod.ts";
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Deno module resolution for `esbuild`.
 This example bundles an entrypoint into a single ESM output.
 
 ```js
-import * as esbuild from "https://deno.land/x/esbuild@v0.17.19/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.js";
 // Import the WASM build on platforms where running subprocesses is not
 // permitted, such as Deno Deploy, or when running without `--allow-run`.
-// import * as esbuild from "https://deno.land/x/esbuild@v0.17.19/wasm.js";
+// import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/wasm.js";
 
 import { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.1/mod.ts";
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Deno module resolution for `esbuild`.
 This example bundles an entrypoint into a single ESM output.
 
 ```js
-import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.js";
 // Import the WASM build on platforms where running subprocesses is not
 // permitted, such as Deno Deploy, or when running without `--allow-run`.
-// import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/wasm.js";
+// import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/wasm.js";
 
 import { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.1/mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-import type * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.d.ts";
+import type * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.d.ts";
 export type { esbuild };
 export {
   dirname,
@@ -6,11 +6,11 @@ export {
   join,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.196.0/path/mod.ts";
-export { copy } from "https://deno.land/std@0.196.0/fs/mod.ts";
-export { basename, extname } from "https://deno.land/std@0.196.0/path/mod.ts";
-export * as JSONC from "https://deno.land/std@0.196.0/jsonc/mod.ts";
-export { encode as base32Encode } from "https://deno.land/std@0.196.0/encoding/base32.ts";
+} from "https://deno.land/std@0.201.0/path/mod.ts";
+export { copy } from "https://deno.land/std@0.201.0/fs/mod.ts";
+export { basename, extname } from "https://deno.land/std@0.201.0/path/mod.ts";
+export * as JSONC from "https://deno.land/std@0.201.0/jsonc/mod.ts";
+export { encode as base32Encode } from "https://deno.land/std@0.201.0/encoding/base32.ts";
 export {
   resolveImportMap,
   resolveModuleSpecifier,

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-import type * as esbuild from "https://deno.land/x/esbuild@v0.17.19/mod.d.ts";
+import type * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.d.ts";
 export type { esbuild };
 export {
   dirname,
@@ -6,11 +6,11 @@ export {
   join,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.173.0/path/mod.ts";
-export { copy } from "https://deno.land/std@0.173.0/fs/mod.ts";
-export { basename, extname } from "https://deno.land/std@0.173.0/path/mod.ts";
-export * as JSONC from "https://deno.land/std@0.173.0/encoding/jsonc.ts";
-export { encode as base32Encode } from "https://deno.land/std@0.173.0/encoding/base32.ts";
+} from "https://deno.land/std@0.195.0/path/mod.ts";
+export { copy } from "https://deno.land/std@0.195.0/fs/mod.ts";
+export { basename, extname } from "https://deno.land/std@0.195.0/path/mod.ts";
+export * as JSONC from "https://deno.land/std@0.195.0/jsonc/mod.ts";
+export { encode as base32Encode } from "https://deno.land/std@0.195.0/encoding/base32.ts";
 export {
   resolveImportMap,
   resolveModuleSpecifier,

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-import type * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.d.ts";
+import type * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.d.ts";
 export type { esbuild };
 export {
   dirname,
@@ -6,11 +6,11 @@ export {
   join,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.195.0/path/mod.ts";
-export { copy } from "https://deno.land/std@0.195.0/fs/mod.ts";
-export { basename, extname } from "https://deno.land/std@0.195.0/path/mod.ts";
-export * as JSONC from "https://deno.land/std@0.195.0/jsonc/mod.ts";
-export { encode as base32Encode } from "https://deno.land/std@0.195.0/encoding/base32.ts";
+} from "https://deno.land/std@0.196.0/path/mod.ts";
+export { copy } from "https://deno.land/std@0.196.0/fs/mod.ts";
+export { basename, extname } from "https://deno.land/std@0.196.0/path/mod.ts";
+export * as JSONC from "https://deno.land/std@0.196.0/jsonc/mod.ts";
+export { encode as base32Encode } from "https://deno.land/std@0.196.0/encoding/base32.ts";
 export {
   resolveImportMap,
   resolveModuleSpecifier,

--- a/examples/bundle.ts
+++ b/examples/bundle.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 await esbuild.build({

--- a/examples/bundle.ts
+++ b/examples/bundle.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 await esbuild.build({

--- a/examples/bundle.ts
+++ b/examples/bundle.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.17.19/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 await esbuild.build({

--- a/examples/custom_scheme_plugin.ts
+++ b/examples/custom_scheme_plugin.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 import { get } from "https://deno.land/x/emoji@0.2.1/mod.ts";

--- a/examples/custom_scheme_plugin.ts
+++ b/examples/custom_scheme_plugin.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.18.17/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 import { get } from "https://deno.land/x/emoji@0.2.1/mod.ts";

--- a/examples/custom_scheme_plugin.ts
+++ b/examples/custom_scheme_plugin.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.17.19/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.18.15/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 import { get } from "https://deno.land/x/emoji@0.2.1/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -5,5 +5,5 @@ export {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.195.0/assert/mod.ts";
-export { join } from "https://deno.land/std@0.195.0/path/mod.ts";
+} from "https://deno.land/std@0.196.0/assert/mod.ts";
+export { join } from "https://deno.land/std@0.196.0/path/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,9 +1,9 @@
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.18.17/mod.js";
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.18.17/wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.19.2/mod.js";
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.19.2/wasm.js";
 export { esbuildNative, esbuildWasm };
 export {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.196.0/assert/mod.ts";
-export { join } from "https://deno.land/std@0.196.0/path/mod.ts";
+} from "https://deno.land/std@0.201.0/assert/mod.ts";
+export { join } from "https://deno.land/std@0.201.0/path/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,9 +1,9 @@
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.17.19/mod.js";
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.17.19/wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.18.15/mod.js";
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.18.15/wasm.js";
 export { esbuildNative, esbuildWasm };
 export {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.185.0/testing/asserts.ts";
-export { join } from "https://deno.land/std@0.185.0/path/mod.ts";
+} from "https://deno.land/std@0.195.0/assert/mod.ts";
+export { join } from "https://deno.land/std@0.195.0/path/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,5 +1,5 @@
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.18.15/mod.js";
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.18.15/wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.18.17/mod.js";
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.18.17/wasm.js";
 export { esbuildNative, esbuildWasm };
 export {
   assert,


### PR DESCRIPTION
I tried fixing https://github.com/denoland/fresh/issues/1421 by increasing the version to 0.18.15, but I was getting a type error complaining about 0.17.19. I see we're still using that here, so I thought I'd increase the versions here.