### PR TITLE
fix: Move temp folder instead of renaming

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -7,7 +7,7 @@ export {
   resolve,
   toFileUrl,
 } from "https://deno.land/std@0.201.0/path/mod.ts";
-export { copy } from "https://deno.land/std@0.201.0/fs/mod.ts";
+export { copy, exists, move } from "https://deno.land/std@0.201.0/fs/mod.ts";
 export { basename, extname } from "https://deno.land/std@0.201.0/path/mod.ts";
 export * as JSONC from "https://deno.land/std@0.201.0/jsonc/mod.ts";
 export { encode as base32Encode } from "https://deno.land/std@0.201.0/encoding/base32.ts";

--- a/src/loader_native.ts
+++ b/src/loader_native.ts
@@ -122,7 +122,10 @@ export class NativeLoader implements Loader {
 
     // check if the package is already linked, if so, return the link and skip
     // a bunch of work
-    if (await exists(linkDir)) return linkDir;
+    if (await exists(linkDir)) {
+      this.#linkDirCache.set(npmPackageId, linkDir);
+      return linkDir;
+    }
 
     // create a temporary directory, recursively hardlink the package contents
     // into it, and then rename it to the final location


### PR DESCRIPTION
## What does this change?

Use `move` method from `std/fs`, which returns the correct errors for existing files.

## Why?

Fixes #82

There may be a deeper issue, which is that we do not get the correct underlying error from the filesystem:

https://github.com/denoland/deno_core/blob/69891d0685d8e0ab5d80d6e3204c241796046a30/core/error_codes.rs#L50C52-L50C52