### PR TITLE
chore: bump esbuild to 0.19.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Deno module resolution for `esbuild`.
 This example bundles an entrypoint into a single ESM output.
 
 ```js
-import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.19.10/mod.js";
 // Import the WASM build on platforms where running subprocesses is not
 // permitted, such as Deno Deploy, or when running without `--allow-run`.
-// import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/wasm.js";
+// import * as esbuild from "https://deno.land/x/esbuild@v0.19.10/wasm.js";
 
 import { denoPlugins } from "https://deno.land/x/esbuild_deno_loader@0.8.2/mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-import type * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.d.ts";
+import type * as esbuild from "https://deno.land/x/esbuild@v0.19.10/mod.d.ts";
 export type { esbuild };
 export {
   dirname,

--- a/examples/bundle.ts
+++ b/examples/bundle.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.19.10/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 await esbuild.build({

--- a/examples/custom_scheme_plugin.ts
+++ b/examples/custom_scheme_plugin.ts
@@ -1,4 +1,4 @@
-import * as esbuild from "https://deno.land/x/esbuild@v0.19.2/mod.js";
+import * as esbuild from "https://deno.land/x/esbuild@v0.19.10/mod.js";
 import { denoPlugins } from "../mod.ts";
 
 import { get } from "https://deno.land/x/emoji@0.2.1/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,5 +1,5 @@
-import * as esbuildNative from "https://deno.land/x/esbuild@v0.19.2/mod.js";
-import * as esbuildWasm from "https://deno.land/x/esbuild@v0.19.2/wasm.js";
+import * as esbuildNative from "https://deno.land/x/esbuild@v0.19.10/mod.js";
+import * as esbuildWasm from "https://deno.land/x/esbuild@v0.19.10/wasm.js";
 export { esbuildNative, esbuildWasm };
 export {
   assert,


### PR DESCRIPTION
This fixes type errors in library users who have upgraded to the latest esbuild.