### PR TITLE
fix: obeys esbuild's external argument

### DIFF
--- a/src/plugin_deno_resolver.ts
+++ b/src/plugin_deno_resolver.ts
@@ -7,11 +7,7 @@ import {
   SpecifierMap,
   toFileUrl,
 } from "../deps.ts";
-import {
-  esbuildResolutionToURL,
-  readDenoConfig,
-  urlToEsbuildResolution,
-} from "./shared.ts";
+import { readDenoConfig, urlToEsbuildResolution } from "./shared.ts";
 
 export type { ImportMap, Scopes, SpecifierMap };
 

--- a/src/plugin_deno_resolver.ts
+++ b/src/plugin_deno_resolver.ts
@@ -148,6 +148,10 @@ export function denoResolverPlugin(
           kind: args.kind,
         });
         if (res.pluginData === IN_NODE_MODULES) nodeModulesPaths.add(res.path);
+        if (build.initialOptions.external)
+          for (const external of build.initialOptions.external)
+            if (new RegExp('^' + external.replace(/[-/\\^$+?.()|[\]{}]/g, '\\$&').replace(/\*/g, '.*') + '$').test(args.path))
+              return { path: args.path, external: true };
         return res;
       });
     },

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -4,6 +4,7 @@ export { esbuildNative, esbuildWasm };
 export {
   assert,
   assertEquals,
+  assertStringIncludes,
   assertThrows,
 } from "https://deno.land/std@0.211.0/assert/mod.ts";
 export { join } from "https://deno.land/std@0.211.0/path/mod.ts";

--- a/testdata/externals.ts
+++ b/testdata/externals.ts
@@ -1,0 +1,2 @@
+export { a } from "foo:bar";
+export { b } from "foo:baz/bar";


### PR DESCRIPTION
This pull requests fixes this issue https://github.com/lucacasonato/esbuild_deno_loader/issues/31

The plugin now handles esbuild's external argument properly accepting wildcards