### PR TITLE
To use symlink instead of hard link on builds

### DIFF
--- a/src/loader_native.ts
+++ b/src/loader_native.ts
@@ -175,6 +175,6 @@ async function linkRecursive(from: string, to: string) {
       await linkRecursive(join(from, entry.name), join(to, entry.name));
     }
   } else {
-    await Deno.link(from, to);
+    await Deno.symlink(from, to);
   }
 }


### PR DESCRIPTION
When building a project with `deno run --node-modules-dir=false -A dev.ts build` we encountered the following error:

```
ERROR: [plugin: deno-loader] Invalid cross-device link (os error 18): link '/cache/npm/registry.npmjs.org/minisearch/6.3.0/CHANGELOG.md' -> '/tmp/ee241569/CHANGELOG.md'
```

We were able to connect this error to the use of hard links instead of symlinks in the build process. Changing this to symlinks resulted in a successful build process.