### PR TITLE
feat: support embedded import map expansion

### DIFF
--- a/src/plugin_deno_resolver.ts
+++ b/src/plugin_deno_resolver.ts
@@ -7,7 +7,11 @@ import {
   SpecifierMap,
   toFileUrl,
 } from "../deps.ts";
-import { readDenoConfig, urlToEsbuildResolution } from "./shared.ts";
+import {
+  expandEmbeddedImportMap,
+  readDenoConfig,
+  urlToEsbuildResolution,
+} from "./shared.ts";
 
 export type { ImportMap, Scopes, SpecifierMap };
 
@@ -76,6 +80,7 @@ export function denoResolverPlugin(
               imports: config.imports,
               scopes: config.scopes,
             } as ImportMap;
+            expandEmbeddedImportMap(configImportMap);
             importMap = resolveImportMap(
               configImportMap,
               toFileUrl(options.configPath),

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,11 @@
-import { esbuild, extname, fromFileUrl, ImportMap, JSONC, toFileUrl } from "../deps.ts";
+import {
+  esbuild,
+  extname,
+  fromFileUrl,
+  ImportMap,
+  JSONC,
+  toFileUrl,
+} from "../deps.ts";
 import { MediaType } from "./deno.ts";
 
 export interface Loader {
@@ -325,7 +332,6 @@ export function parseJsrSpecifier(specifier: URL): JsrSpecifier {
     path: pathStartIndex === path.length ? null : path.slice(pathStartIndex),
   };
 }
-
 
 // For all pairs in `imports` where the specifier does not end in a /, and the
 // target starts with `jsr:` or `npm:`, and no entry exists for `${specifier}/`,

--- a/src/shared_test.ts
+++ b/src/shared_test.ts
@@ -1,10 +1,12 @@
 import {
+  expandEmbeddedImportMap,
   NpmSpecifier,
   parseJsrSpecifier,
   parseNpmSpecifier,
 } from "./shared.ts";
 import { assertEquals, assertThrows } from "../test_deps.ts";
 import { JsrSpecifier } from "./shared.ts";
+import { ImportMap } from "../deps.ts";
 
 interface NpmSpecifierTestCase extends NpmSpecifier {
   specifier: string;
@@ -189,4 +191,31 @@ Deno.test("parseJsrSpecifier", async (t) => {
       );
     });
   }
+});
+
+Deno.test("expandEmbeddedImportMap", () => {
+  const importMap: ImportMap = {
+    imports: {
+      "@std/path": "jsr:@std/path@1.2.3",
+      "preact": "npm:preact@^10.0.0",
+      "preact2": "npm:/preact2@^10.0.0",
+
+      "preact-render-to-string": "jsr:preact-render-to-string",
+      "preact-render-to-string/": "jsr:preact-render-to-string2/",
+    },
+  };
+  expandEmbeddedImportMap(importMap);
+  assertEquals(importMap, {
+    imports: {
+      "@std/path": "jsr:@std/path@1.2.3",
+      "@std/path/": "jsr:/@std/path@1.2.3/",
+      "preact": "npm:preact@^10.0.0",
+      "preact/": "npm:/preact@^10.0.0/",
+      "preact2": "npm:/preact2@^10.0.0",
+      "preact2/": "npm:/preact2@^10.0.0/",
+
+      "preact-render-to-string": "jsr:preact-render-to-string",
+      "preact-render-to-string/": "jsr:preact-render-to-string2/",
+    },
+  });
 });

--- a/testdata/config_inline_expansion.json
+++ b/testdata/config_inline_expansion.json
@@ -1,0 +1,6 @@
+{
+  "lock": "./jsr/deno.lock",
+  "imports": {
+    "@std/path": "jsr:@std/path@^0.213"
+  }
+}

--- a/testdata/mapped_jsr.js
+++ b/testdata/mapped_jsr.js
@@ -1,0 +1,1 @@
+export * from "@std/path/join";


### PR DESCRIPTION
This supports the embedded import map expansion feature from Deno 1.40: https://deno.com/blog/v1.40#simpler-imports-in-denojson
