### PR TITLE
refactor: clean up node_modules/ importing code

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,6 +5,7 @@ export {
   fromFileUrl,
   join,
   resolve,
+  SEPARATOR,
   toFileUrl,
 } from "https://deno.land/std@0.213.0/path/mod.ts";
 export { copy } from "https://deno.land/std@0.213.0/fs/mod.ts";

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -432,6 +432,35 @@ Deno.test("npm specifiers global resolver - typo-js", async (t) => {
   });
 });
 
+Deno.test("npm specifiers global resolver - express", async (t) => {
+  await testLoader(t, ["native"], async (esbuild, loader) => {
+    if (esbuild === PLATFORMS.wasm) return;
+    const res = await esbuild.build({
+      ...DEFAULT_OPTS,
+      plugins: [...denoPlugins({ loader })],
+      bundle: true,
+      entryPoints: ["npm:express@4"],
+      platform: "node",
+    });
+    assertEquals(res.warnings, []);
+    assertEquals(res.errors, []);
+    assertEquals(res.outputFiles.length, 1);
+    const output = res.outputFiles[0];
+    assertEquals(output.path, "<stdout>");
+    assert(!output.text.includes(`npm:`));
+    console.log(output.text);
+    const blobURL = URL.createObjectURL(
+      new Blob([
+        "import { createRequire } from 'node:module';\nimport process from 'node:process';\nconst require = createRequire('file:///');\n",
+        output.text,
+      ], { type: "text/javascript" }),
+    );
+    const { default: express } = await import(blobURL);
+    URL.revokeObjectURL(blobURL);
+    assertEquals(typeof express, "function");
+  });
+});
+
 Deno.test("npm specifiers local resolver - preact", async (t) => {
   await testLoader(t, LOADERS, async (esbuild, loader) => {
     if (esbuild === PLATFORMS.wasm) return;
@@ -557,7 +586,7 @@ Deno.test("npm specifiers local resolver - @oramacloud/client", async (t) => {
 });
 
 Deno.test("npm specifiers local resolver - typo-js", async (t) => {
-  await testLoader(t, LOADERS, async (esbuild, loader) => {
+  await testLoader(t, ["portable"], async (esbuild, loader) => {
     if (esbuild === PLATFORMS.wasm) return;
     const tmp = Deno.makeTempDirSync();
     if (loader === "portable") {
@@ -582,6 +611,42 @@ Deno.test("npm specifiers local resolver - typo-js", async (t) => {
     const dataURL = `data:application/javascript;base64,${btoa(output.text)}`;
     const { default: Typo } = await import(dataURL);
     assertEquals(typeof Typo, "function");
+  });
+});
+
+Deno.test("npm specifiers local resolver - express", async (t) => {
+  await testLoader(t, ["portable"], async (esbuild, loader) => {
+    if (esbuild === PLATFORMS.wasm) return;
+    const tmp = Deno.makeTempDirSync();
+    if (loader === "portable") {
+      new Deno.Command(Deno.execPath(), {
+        args: ["cache", "--node-modules-dir", "npm:express@4"],
+        cwd: tmp,
+      }).outputSync();
+    }
+    const res = await esbuild.build({
+      ...DEFAULT_OPTS,
+      plugins: [...denoPlugins({ loader, nodeModulesDir: true })],
+      bundle: true,
+      absWorkingDir: tmp,
+      entryPoints: ["npm:express@4"],
+      platform: "node",
+    });
+    assertEquals(res.warnings, []);
+    assertEquals(res.errors, []);
+    assertEquals(res.outputFiles.length, 1);
+    const output = res.outputFiles[0];
+    assertEquals(output.path, "<stdout>");
+    console.log(output.text);
+    const blobURL = URL.createObjectURL(
+      new Blob([
+        "import { createRequire } from 'node:module';\nimport process from 'node:process';\nconst require = createRequire('file:///');\n",
+        output.text,
+      ], { type: "text/javascript" }),
+    );
+    const { default: express } = await import(blobURL);
+    URL.revokeObjectURL(blobURL);
+    assertEquals(typeof express, "function");
   });
 });
 

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -448,7 +448,6 @@ Deno.test("npm specifiers global resolver - express", async (t) => {
     const output = res.outputFiles[0];
     assertEquals(output.path, "<stdout>");
     assert(!output.text.includes(`npm:`));
-    console.log(output.text);
     const blobURL = URL.createObjectURL(
       new Blob([
         "import { createRequire } from 'node:module';\nimport process from 'node:process';\nconst require = createRequire('file:///');\n",
@@ -637,7 +636,6 @@ Deno.test("npm specifiers local resolver - express", async (t) => {
     assertEquals(res.outputFiles.length, 1);
     const output = res.outputFiles[0];
     assertEquals(output.path, "<stdout>");
-    console.log(output.text);
     const blobURL = URL.createObjectURL(
       new Blob([
         "import { createRequire } from 'node:module';\nimport process from 'node:process';\nconst require = createRequire('file:///');\n",

--- a/src/loader_native.ts
+++ b/src/loader_native.ts
@@ -138,12 +138,10 @@ export class NativeLoader implements Loader {
       await Deno.mkdir(linkDirParent, { recursive: true });
       await Deno.rename(tmpDir, linkDir);
     } catch (err) {
-      if (
-        err instanceof Deno.errors.AlreadyExists ||
-        err.code === "ENOTEMPTY"
-      ) {
-        // ignore, someone else created the directory already
-      } else {
+      // the directory may already have been created by someone else - check if so
+      try {
+        await Deno.stat(linkDir);
+      } catch {
         throw err;
       }
     }

--- a/src/loader_native.ts
+++ b/src/loader_native.ts
@@ -154,7 +154,7 @@ export class NativeLoader implements Loader {
   packageIdFromNameInPackage(
     name: string,
     parentPackageId: string,
-  ): string {
+  ): string | null {
     const parentPackage = this.#infoCache.getNpmPackage(parentPackageId);
     if (!parentPackage) throw new Error("NPM package not found.");
     if (parentPackage.name === name) return parentPackageId;
@@ -163,7 +163,7 @@ export class NativeLoader implements Loader {
       if (!depPackage) throw new Error("NPM package not found.");
       if (depPackage.name === name) return dep;
     }
-    throw new Error("NPM package not found.");
+    return null;
   }
 }
 

--- a/src/plugin_deno_loader.ts
+++ b/src/plugin_deno_loader.ts
@@ -345,7 +345,7 @@ export function denoLoaderPlugin(
       build.onResolve({ filter: /.*/, namespace: "jsr" }, onResolve);
       build.onResolve({ filter: /.*/, namespace: "node" }, onResolve);
 
-      async function onLoad(
+      function onLoad(
         args: esbuild.OnLoadArgs,
       ): Promise<esbuild.OnLoadResult | null> | undefined {
         if (args.namespace === "file" && isInNodeModules(args.path)) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -4,6 +4,7 @@ import {
   fromFileUrl,
   ImportMap,
   JSONC,
+  SEPARATOR,
   toFileUrl,
 } from "../deps.ts";
 import { MediaType } from "./deno.ts";
@@ -360,8 +361,12 @@ export function expandEmbeddedImportMap(importMap: ImportMap) {
   }
 }
 
+const SLASH_NODE_MODULES_SLASH = `${SEPARATOR}node_modules${SEPARATOR}`;
+const SLASH_NODE_MODULES = `${SEPARATOR}node_modules`;
+
 export function isInNodeModules(path: string): boolean {
-  return path.includes("/node_modules/") || path.endsWith("/node_modules");
+  return path.includes(SLASH_NODE_MODULES_SLASH) ||
+    path.endsWith(SLASH_NODE_MODULES);
 }
 
 export function isNodeModulesResolution(args: esbuild.OnResolveArgs) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,7 +12,10 @@ export interface Loader {
   resolve(specifier: URL): Promise<LoaderResolution>;
   loadEsm(specifier: URL): Promise<esbuild.OnLoadResult>;
 
-  packageIdFromNameInPackage?(name: string, parentPackageId: string): string;
+  packageIdFromNameInPackage?(
+    name: string,
+    parentPackageId: string,
+  ): string | null;
   nodeModulesDirForPackage?(npmPackageId?: string): Promise<string>;
 }
 
@@ -355,4 +358,16 @@ export function expandEmbeddedImportMap(importMap: ImportMap) {
     }
     importMap.imports = Object.fromEntries(newImports);
   }
+}
+
+export function isInNodeModules(path: string): boolean {
+  return path.includes("/node_modules/") || path.endsWith("/node_modules");
+}
+
+export function isNodeModulesResolution(args: esbuild.OnResolveArgs) {
+  return (
+    (args.namespace === "" || args.namespace === "file") &&
+    (isInNodeModules(args.resolveDir) || isInNodeModules(args.path) ||
+      isInNodeModules(args.importer))
+  );
 }


### PR DESCRIPTION
This commit cleans up the node_modules/ resolution logic significantly, deferring more to esbuild (giving better error messages in the process). I think this speeds up our resolution when involving node_modules/ by ~50%.