### PR TITLE
Use JSR_URL env var as an option to be conformant with deno runtime itself

### DIFF
--- a/src/loader_portable.ts
+++ b/src/loader_portable.ts
@@ -16,7 +16,7 @@ interface Module {
   data: Uint8Array;
 }
 
-const JSR_REGISTRY_URL = Deno.env.get("DENO_REGISTRY_URL") ?? "https://jsr.io";
+const JSR_REGISTRY_URL = Deno.env.get("DENO_REGISTRY_URL") ?? Deno.env.get("JSR_URL") ?? "https://jsr.io";
 
 async function readLockfile(path: string): Promise<deno.Lockfile | null> {
   try {

--- a/src/loader_portable.ts
+++ b/src/loader_portable.ts
@@ -16,7 +16,13 @@ interface Module {
   data: Uint8Array;
 }
 
-const JSR_REGISTRY_URL = Deno.env.get("DENO_REGISTRY_URL") ?? Deno.env.get("JSR_URL") ?? "https://jsr.io";
+const DENO_REGISTRY_URL = Deno.env.get("DENO_REGISTRY_URL");
+
+if (typeof DENO_REGISTRY_URL !== "undefined") {
+  console.warn(`DENO_REGISTRY_URL is deprecated use JSR_URL instead`);
+}
+
+const JSR_REGISTRY_URL = DENO_REGISTRY_URL ?? Deno.env.get("JSR_URL") ?? "https://jsr.io";
 
 async function readLockfile(path: string): Promise<deno.Lockfile | null> {
   try {


### PR DESCRIPTION
keeping compatibility with DENO_REGISTRY_URL