### PR TITLE
feat: add specifiers filter

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -13,9 +13,11 @@ import {
 } from "./src/plugin_deno_loader.ts";
 export { DEFAULT_LOADER, denoLoaderPlugin, DenoLoaderPluginOptions };
 
+import type { Specifiers } from "./src/shared.ts";
 export {
   type EsbuildResolution,
   esbuildResolutionToURL,
+  type Specifiers,
   urlToEsbuildResolution,
 } from "./src/shared.ts";
 
@@ -65,6 +67,12 @@ export interface DenoPluginsOptions {
    * loader always uses a local `node_modules` directory.
    */
   nodeModulesDir?: boolean;
+  /**
+   * Which specifiers will be resolved.
+   *
+   * If this option is not specified, all specifiers will be provided.
+   */
+  specifiers?: Specifiers;
 }
 
 /**

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -390,3 +390,26 @@ export function isNodeModulesResolution(args: esbuild.OnResolveArgs) {
       isInNodeModules(args.importer))
   );
 }
+
+/**
+ * List of specifiers that can be resolved.
+ */
+export interface Specifiers {
+  file?: boolean;
+  http?: boolean;
+  https?: boolean;
+  data?: boolean;
+  npm?: boolean;
+  jsr?: boolean;
+  node?: boolean;
+}
+
+export const DEFAULT_SPECIFIERS: Specifiers = {
+  file: true,
+  http: true,
+  https: true,
+  data: true,
+  npm: true,
+  jsr: true,
+  node: true,
+};


### PR DESCRIPTION
When setting up complicated esbuild configs, it's common to want to let other plugins handle certain specifiers. For example, `node:` might need to be handled by a polyfill plugin.