### PR TITLE
docs: wasm module url in the main readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This example bundles an entrypoint into a single ESM output.
 import * as esbuild from "npm:esbuild@0.20.2";
 // Import the WASM build on platforms where running subprocesses is not
 // permitted, such as Deno Deploy, or when running without `--allow-run`.
-// import * as esbuild from "https://deno.land/x/esbuild@0.20.2/wasm.js";
+// import * as esbuild from "https://deno.land/x/esbuild@v0.20.2/wasm.js";
 
 import { denoPlugins } from "jsr:@luca/esbuild-deno-loader@^0.10.3";
 


### PR DESCRIPTION
Existing one 404ed