### PR TITLE
feat: don't error on unrecognized media types in loader

### DIFF
--- a/src/esbuild_types.ts
+++ b/src/esbuild_types.ts
@@ -62,7 +62,7 @@ export interface PluginBuild {
   /** Documentation: https://esbuild.github.io/plugins/#on-load */
   onLoad(
     options: OnLoadOptions,
-    callback: (args: OnLoadArgs) => Promise<OnLoadResult | null> | undefined,
+    callback: (args: OnLoadArgs) => Promise<OnLoadResult | null | undefined> | undefined,
   ): void;
 }
 

--- a/src/esbuild_types.ts
+++ b/src/esbuild_types.ts
@@ -62,7 +62,9 @@ export interface PluginBuild {
   /** Documentation: https://esbuild.github.io/plugins/#on-load */
   onLoad(
     options: OnLoadOptions,
-    callback: (args: OnLoadArgs) => Promise<OnLoadResult | null | undefined> | undefined,
+    callback: (
+      args: OnLoadArgs,
+    ) => Promise<OnLoadResult | null | undefined> | undefined,
   ): void;
 }
 

--- a/src/loader_portable.ts
+++ b/src/loader_portable.ts
@@ -144,7 +144,7 @@ export class PortableLoader implements Loader, Disposable {
     );
   }
 
-  async loadEsm(url: URL): Promise<esbuild.OnLoadResult> {
+  async loadEsm(url: URL): Promise<esbuild.OnLoadResult | undefined> {
     let module: Module;
     switch (url.protocol) {
       case "file:": {
@@ -162,6 +162,7 @@ export class PortableLoader implements Loader, Disposable {
     }
 
     const loader = mediaTypeToLoader(module.mediaType);
+    if (loader === null) return undefined;
 
     const res: esbuild.OnLoadResult = { contents: module.data, loader };
     if (url.protocol === "file:") {

--- a/src/plugin_deno_loader.ts
+++ b/src/plugin_deno_loader.ts
@@ -375,7 +375,7 @@ export function denoLoaderPlugin(
 
       function onLoad(
         args: esbuild.OnLoadArgs,
-      ): Promise<esbuild.OnLoadResult | null> | undefined {
+      ): Promise<esbuild.OnLoadResult | null | undefined> | undefined {
         if (args.namespace === "file" && isInNodeModules(args.path)) {
           // inside node_modules, just let esbuild do it's thing
           return undefined;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -6,7 +6,7 @@ import type * as esbuild from "./esbuild_types.ts";
 
 export interface Loader {
   resolve(specifier: URL): Promise<LoaderResolution>;
-  loadEsm(specifier: URL): Promise<esbuild.OnLoadResult>;
+  loadEsm(specifier: URL): Promise<esbuild.OnLoadResult | undefined>;
 
   packageIdFromNameInPackage?(
     name: string,
@@ -39,7 +39,7 @@ export interface LoaderResolutionNode {
   path: string;
 }
 
-export function mediaTypeToLoader(mediaType: MediaType): esbuild.Loader {
+export function mediaTypeToLoader(mediaType: MediaType): esbuild.Loader | null {
   switch (mediaType) {
     case "JavaScript":
     case "Mjs":
@@ -54,7 +54,7 @@ export function mediaTypeToLoader(mediaType: MediaType): esbuild.Loader {
     case "Json":
       return "json";
     default:
-      throw new Error(`Unhandled media type ${mediaType}.`);
+      return null;
   }
 }
 
@@ -242,7 +242,7 @@ function mapJsLikeExtension(
   }
 }
 
-function mediaTypeFromSpecifier(specifier: URL): MediaType {
+export function mediaTypeFromSpecifier(specifier: URL): MediaType {
   const path = specifier.pathname;
   switch (extname(path)) {
     case "":

--- a/testdata/hello.txt
+++ b/testdata/hello.txt
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
This now makes it possible to implement your own loaders for file types like `.css` or `.txt`.

Closes #129 
Closes #85
